### PR TITLE
fix load issue when window restores on mac

### DIFF
--- a/chrome/content/zoteroquicklook.js
+++ b/chrome/content/zoteroquicklook.js
@@ -10,6 +10,10 @@ Zotero.ZoteroQuickLook = {
     viewerBaseArguments:null,
 
 	init: async function () {
+		if (document.getElementById('zotero-itemmenu') == null) {
+			setTimeout(() => { this.init(); }, 1000);
+			return;
+		}
 		document.getElementById('zotero-itemmenu').addEventListener("popupshowing", this.showQuickLookMenu, false);
 		document.getElementById('zotero-items-tree').addEventListener("keydown",this.onKey,false);
 


### PR DESCRIPTION
This plugin works fine on the first start of Zotero. However, on Mac if you close the window but not quit the application, you can activate or "restore" the window in the dock. After that, the plugin does not work due to init failure. This issue may relate to #26 #29 .

While the issue should be caused by the load orders, my trail on "window.onload" or "document.addEventListener("DOMContentLoaded" failed.

This PR provides an ugly fix by retrying after 1s. It works for me on MacOS Catalina 10.15.6.