### PR TITLE
Add preliminary support for sushi

### DIFF
--- a/chrome/content/zoteroquicklook.js
+++ b/chrome/content/zoteroquicklook.js
@@ -205,13 +205,13 @@ Zotero.ZoteroQuickLook = {
 
 
 			if(Zotero.isLinux){
-        const linux_bins = ["/usr/bin/sushi", "/usr/bin/gloobus-preview"];
-        const linux_existing_bins = linux_bins.filter(bin => Zotero.File.pathToFile(bin).exists());
-        if (linux_existing_bins.length == 0) {
-  				alert("All supported software are mssing [" + linux_bins.toString() + "]. Please install either one or specify a custom view command instead.");
-  				return;
-        }
-        // take the first existing bin as higher priority
+				const linux_bins = ["/usr/bin/sushi", "/usr/bin/gloobus-preview"];
+				const linux_existing_bins = linux_bins.filter(bin => Zotero.File.pathToFile(bin).exists());
+				if (linux_existing_bins.length == 0) {
+					alert("All supported software are mssing [" + linux_bins.toString() + "]. Please install either one or specify a custom view command instead.");
+					return;
+				}
+				// take the first existing bin as higher priority
 				this.viewerExecutable = Zotero.File.pathToFile(linux_existing_bins[0]);
 			}
 

--- a/chrome/content/zoteroquicklook.js
+++ b/chrome/content/zoteroquicklook.js
@@ -205,11 +205,14 @@ Zotero.ZoteroQuickLook = {
 
 
 			if(Zotero.isLinux){
-				this.viewerExecutable = Zotero.File.pathToFile("/usr/bin/gloobus-preview");
-				if(this.viewerExecutable.exists() === false){
-					alert("/usr/bin/gloobus-preview is missing. Please install Gloobus or specify a custom view command instead.");
-					return;
-				}
+        const linux_bins = ["/usr/bin/sushi", "/usr/bin/gloobus-preview"];
+        const linux_existing_bins = linux_bins.filter(bin => Zotero.File.pathToFile(bin).exists());
+        if (linux_existing_bins.length == 0) {
+  				alert("All supported software are mssing [" + linux_bins.toString() + "]. Please install either one or specify a custom view command instead.");
+  				return;
+        }
+        // take the first existing bin as higher priority
+				this.viewerExecutable = Zotero.File.pathToFile(linux_existing_bins[0]);
 			}
 
 			if (this.getPref("usefilenameworkaround")) {

--- a/chrome/content/zoteroquicklook.pl
+++ b/chrome/content/zoteroquicklook.pl
@@ -1,5 +1,8 @@
 #!/usr/bin/perl
 
+use File::Spec;
+use IPC::Open2;
+
 print "\n\nThis file contains debug information\n\n";
 
 my @files=();
@@ -26,6 +29,14 @@ foreach $argnum (0 .. $#ARGV) {
 #
 
 
-if (-e '/usr/bin/qlmanage') { exec('/usr/bin/qlmanage','-p',@files); }
-elsif (-e '/usr/bin/gloobus-preview') { system('/usr/bin/gloobus-preview',@files); }
-else { print "No QuickLook application found"; }
+if (scalar @files > 0) {
+  if (-e '/usr/bin/qlmanage') { exec('/usr/bin/qlmanage','-p',@files); }
+  elsif (-e '/usr/bin/sushi') {
+	# we pass an entire string, instead of a list of args, to `system` because dbus-send needs to run in an actual shell
+    $cmd = 'dbus-send --print-reply --dest=org.gnome.NautilusPreviewer /org/gnome/NautilusPreviewer org.gnome.NautilusPreviewer.ShowFile string:"file://%s" int32:0 boolean:false';
+  	# sushi only support viewing single file
+    system sprintf($cmd,File::Spec->rel2abs($files[0]));
+  }
+  elsif (-e '/usr/bin/gloobus-preview') { system('/usr/bin/gloobus-preview',@files); }
+  else { print "No QuickLook application found"; }
+}

--- a/chrome/content/zoteroquicklook.pl
+++ b/chrome/content/zoteroquicklook.pl
@@ -30,13 +30,13 @@ foreach $argnum (0 .. $#ARGV) {
 
 
 if (scalar @files > 0) {
-  if (-e '/usr/bin/qlmanage') { exec('/usr/bin/qlmanage','-p',@files); }
-  elsif (-e '/usr/bin/sushi') {
-	# we pass an entire string, instead of a list of args, to `system` because dbus-send needs to run in an actual shell
-    $cmd = 'dbus-send --print-reply --dest=org.gnome.NautilusPreviewer /org/gnome/NautilusPreviewer org.gnome.NautilusPreviewer.ShowFile string:"file://%s" int32:0 boolean:false';
-  	# sushi only support viewing single file
-    system sprintf($cmd,File::Spec->rel2abs($files[0]));
-  }
-  elsif (-e '/usr/bin/gloobus-preview') { system('/usr/bin/gloobus-preview',@files); }
-  else { print "No QuickLook application found"; }
+	if (-e '/usr/bin/qlmanage') { exec('/usr/bin/qlmanage','-p',@files); }
+	elsif (-e '/usr/bin/sushi') {
+		# we pass an entire string, instead of a list of args, to `system` because dbus-send needs to run in an actual shell
+		$cmd = 'dbus-send --print-reply --dest=org.gnome.NautilusPreviewer /org/gnome/NautilusPreviewer org.gnome.NautilusPreviewer.ShowFile string:"file://%s" int32:0 boolean:false';
+		# sushi only support viewing single file
+		system sprintf($cmd,File::Spec->rel2abs($files[0]));
+	}
+	elsif (-e '/usr/bin/gloobus-preview') { system('/usr/bin/gloobus-preview',@files); }
+	else { print "No QuickLook application found"; }
 }


### PR DESCRIPTION
This attempts to close #23.

Currently I can confirm that this works for me in Linux by sending dbus message to preview files in Zotero via `sushi`. This support is preliminary because I had only added code path to sushi in the **Perl** script (i.e. the `usefilenameworkaround` flag).

The reason is that the actual js `viewerExecutable` is a bit messy and it currently:
  1. Supply necessary args by relying on appending args via the `viewerBaseArguments` list. However, this does not works for `sushi` as it need to embed the file path in part of its argunment to `dbus-send`.
  2. Code in `js` attempts to support opening multiple files. However, this is not possible in sushi AFAIK.

So the current PR attempt works with default settings (i.e. using the external perl script); however, has no effect if `usefilenameworkaround` flag is set to false.