### PR TITLE
Compatible with Zotero 6.0.

### DIFF
--- a/chrome/content/zoteroquicklook.js
+++ b/chrome/content/zoteroquicklook.js
@@ -453,7 +453,9 @@ Checks the attachment file or writes a content of a note to a file and then push
 	*/
 
 	openQuickLook: async function(items) {
-
+		this.viewerBaseArguments=['-p'];
+        this.viewerExecutable = Zotero.File.pathToFile("/usr/bin/qlmanage");
+		
 		Zotero.debug("ZoteroQuickLook: opening viewer",3);
 
 		var args=this.viewerBaseArguments.slice();

--- a/chrome/content/zoteroquicklook.js
+++ b/chrome/content/zoteroquicklook.js
@@ -453,9 +453,7 @@ Checks the attachment file or writes a content of a note to a file and then push
 	*/
 
 	openQuickLook: async function(items) {
-		this.viewerBaseArguments=['-p'];
-        this.viewerExecutable = Zotero.File.pathToFile("/usr/bin/qlmanage");
-		
+
 		Zotero.debug("ZoteroQuickLook: opening viewer",3);
 
 		var args=this.viewerBaseArguments.slice();

--- a/install.rdf
+++ b/install.rdf
@@ -14,7 +14,7 @@
       <Description>
         <em:id>zotero@chnm.gmu.edu</em:id>
         <em:minVersion>4.0</em:minVersion>
-        <em:maxVersion>5.*</em:maxVersion>
+        <em:maxVersion>6.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:targetApplication>


### PR DESCRIPTION
Following the discussion in issue #44 and make zoteroquicklook compatible with Zotero 6.0 on MacOS.


Directly rename following file to `zoteroquicklook.zoteroplugin`
[zoteroquicklook.zoteroplugin.zip](https://github.com/mronkko/ZoteroQuickLook/files/8357527/zoteroquicklook.zoteroplugin.zip)
